### PR TITLE
Remove extension - #151

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,7 +149,7 @@ function createIndex(path, statsSync) {
                                 "mod": "${statsSync.trim()}",
                                 "tag": "${tag}",
                                 "tagId": "${h.getAttribute('id')}",
-                                "path": "/${urlPath.replace('.md', '.html')}"
+                                "path": "/${urlPath.replace(new RegExp(/(index\.(html|md)|\.(html|md))/), '')}"
                             },`
                             searchDict[title+urlPath] = true
                         }


### PR DESCRIPTION
Change log:
1. Regex will first search for index.html or index.md and replace with nothing, since index is the default name for site directory. Otherwise, just remove the extension for clean url links